### PR TITLE
Allow an ID to be passed in when creating a document.

### DIFF
--- a/server/commands/documentCreator.ts
+++ b/server/commands/documentCreator.ts
@@ -1,7 +1,9 @@
 import invariant from "invariant";
 import { Document, Event, User } from "@server/models";
+import { uuid4 } from "@sentry/utils";
 
 export default async function documentCreator({
+  id = uuid4(),
   title = "",
   text = "",
   publish,
@@ -17,6 +19,7 @@ export default async function documentCreator({
   source,
   ip,
 }: {
+  id: string;
   title: string;
   text: string;
   publish?: boolean;
@@ -34,6 +37,7 @@ export default async function documentCreator({
 }): Promise<Document> {
   const templateId = templateDocument ? templateDocument.id : undefined;
   const document = await Document.create({
+    id,
     parentDocumentId,
     editorVersion,
     collectionId,

--- a/server/routes/api/documents.test.ts
+++ b/server/routes/api/documents.test.ts
@@ -1832,14 +1832,35 @@ describe("#documents.create", () => {
         publish: true,
       },
     });
+    expect(res.status).toEqual(200);
     const body = await res.json();
     const newDocument = await Document.findByPk(body.data.id);
-    expect(res.status).toEqual(200);
     expect(newDocument!.parentDocumentId).toBe(null);
     expect(newDocument!.collectionId).toBe(collection.id);
     expect(body.policies[0].abilities.update).toEqual(true);
   });
 
+  it("should create a new document with a specified id", async () => {
+    const { user, collection } = await seed();
+    const myId = "765affa5-5b1c-4ee9-a9fc-1e34e3f5f5d6";
+    const res = await server.post("/api/documents.create", {
+      body: {
+        token: user.getJwtToken(),
+        id: myId,
+        collectionId: collection.id,
+        title: "new document",
+        text: "hello",
+        publish: true,
+      },
+    });
+    expect(res.status).toEqual(200);
+    const body = await res.json();
+    expect(body.data.id).toBe(myId);
+    const newDocument = await Document.findByPk(body.data.id);
+    expect(newDocument!.parentDocumentId).toBe(null);
+    expect(newDocument!.collectionId).toBe(collection.id);
+    expect(body.policies[0].abilities.update).toEqual(true);
+  });
   it("should not allow very long titles", async () => {
     const { user, collection } = await seed();
     const res = await server.post("/api/documents.create", {

--- a/server/routes/api/documents.ts
+++ b/server/routes/api/documents.ts
@@ -40,6 +40,7 @@ import {
 } from "@server/validation";
 import env from "../../env";
 import pagination from "./middlewares/pagination";
+import { uuid4 } from "@sentry/utils";
 
 const router = new Router();
 
@@ -1356,7 +1357,7 @@ router.post("documents.import", auth(), async (ctx) => {
 
 router.post("documents.create", auth(), async (ctx) => {
   const {
-    id,
+    id = uuid4(),
     title = "",
     text = "",
     publish,

--- a/server/routes/api/documents.ts
+++ b/server/routes/api/documents.ts
@@ -1356,6 +1356,7 @@ router.post("documents.import", auth(), async (ctx) => {
 
 router.post("documents.create", auth(), async (ctx) => {
   const {
+    id,
     title = "",
     text = "",
     publish,
@@ -1410,6 +1411,7 @@ router.post("documents.create", auth(), async (ctx) => {
   }
 
   const document = await documentCreator({
+    id,
     title,
     text,
     publish,


### PR DESCRIPTION
The intent here is that an `id` can be passed in on the `documents.create` call. If it is, it will be the one used when creating the document. Otherwise, it will generate one just like before.